### PR TITLE
Add GitHub Actions deploy workflow and API key injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Inject API Key
+        run: |
+          # Replace the placeholder with the GitHub secret
+          sed -i "s/GITHUB_API_KEY/${{ secrets.QUOTIFY_API_KEY }}/g" index.html
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/GITHUB_SETUP.md
+++ b/GITHUB_SETUP.md
@@ -8,7 +8,7 @@
 2. Click on **Settings** → **Secrets and variables** → **Actions**
 3. Click **New repository secret**
 4. Name: `QUOTIFY_API_KEY`
-5. Value: Your API key (`qapi_8ff2baa56316ce39537f95d8941b06c90e75748a99d098a817cc93f80b731f20`)
+5. Value: Your API key (`qapi_`)
 6. Click **Add secret**
 
 ### Step 2: GitHub Actions Workflow

--- a/GITHUB_SETUP.md
+++ b/GITHUB_SETUP.md
@@ -1,0 +1,37 @@
+# GitHub Environment Variable Setup
+
+## Setting up the API Key as a GitHub Secret
+
+### Step 1: Add GitHub Secret
+
+1. Go to your GitHub repository
+2. Click on **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Name: `QUOTIFY_API_KEY`
+5. Value: Your API key (`qapi_8ff2baa56316ce39537f95d8941b06c90e75748a99d098a817cc93f80b731f20`)
+6. Click **Add secret**
+
+### Step 2: GitHub Actions Workflow
+
+The `.github/workflows/deploy.yml` file is already configured to:
+- Replace `GITHUB_API_KEY` placeholder in `index.html` with your secret
+- Deploy to GitHub Pages automatically
+
+### Step 3: Verify
+
+After pushing to the `main` branch:
+- GitHub Actions will automatically run
+- The API key will be injected into `index.html`
+- Your site will be deployed with the secure API key
+
+## Manual Replacement (Alternative)
+
+If you prefer not to use GitHub Actions, you can manually replace `GITHUB_API_KEY` in `index.html` with your actual API key before deploying.
+
+## Security Notes
+
+- ✅ API key is stored securely in GitHub Secrets
+- ✅ Never commit the actual API key to the repository
+- ✅ The placeholder `GITHUB_API_KEY` is safe to commit
+- ✅ Only GitHub Actions can access the secret during deployment
+

--- a/index.html
+++ b/index.html
@@ -192,13 +192,21 @@
 
     <script>
         // Configuration
+        // API key will be injected from GitHub environment variable during build/deployment
         const config = {
             endpoint: 'https://quotify.dazzelr.tech',
+            apiKey: 'GITHUB_API_KEY', // This will be replaced by GitHub Actions with ${{ secrets.QUOTIFY_API_KEY }}
             paths: {
                 quotes: '/api',
                 types: '/api/types'
             }
         };
+        
+        // Get API key (placeholder for GitHub variable injection)
+        function getApiKey() {
+            // In production, this will be replaced with the actual GitHub secret
+            return config.apiKey === 'GITHUB_API_KEY' ? null : config.apiKey;
+        }
         
         // Fallback quotes in case API fails
         const fallbackQuotes = [
@@ -236,9 +244,18 @@
         // Fetch quote from API
         async function fetchQuoteFromAPI(category = '') {
             try {
+                const apiKey = getApiKey();
+                if (!apiKey) {
+                    throw new Error('API key not configured');
+                }
+                
                 const baseUrl = config.endpoint + config.paths.quotes;
                 const url = category ? `${baseUrl}?type=${category}` : baseUrl;
-                const response = await fetch(url);
+                const response = await fetch(url, {
+                    headers: {
+                        'x-api-key': apiKey
+                    }
+                });
                 
                 if (!response.ok) {
                     throw new Error(`API Error: ${response.status}`);


### PR DESCRIPTION
Introduces a GitHub Actions workflow to deploy to GitHub Pages and inject the API key from repository secrets into index.html. Adds GITHUB_SETUP.md with setup instructions, and updates index.html to use a placeholder for the API key, which is replaced during deployment. Also refactors API key handling in the JavaScript to support this workflow.